### PR TITLE
Change ID generation in hapi-connect

### DIFF
--- a/packages/hapi-connect/package.json
+++ b/packages/hapi-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbytes/hapi-connect",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Lightweight HashConnect Browser Side Client Library",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/bugbytesinc/hapi-proto#readme",
   "peerDependencies": {    
-    "@bugbytes/hapi-proto": "0.31.9",
-    "@bugbytes/hapi-util": "0.31.9",
+    "@bugbytes/hapi-proto": "0.31.10",
+    "@bugbytes/hapi-util": "0.31.10",
     "long": ">=5.2.0",
     "protobufjs": ">=7.1.2",
     "simple-crypto-js": "^3.0.1",

--- a/packages/hapi-connect/src/cache.ts
+++ b/packages/hapi-connect/src/cache.ts
@@ -3,11 +3,7 @@ import { type TransactionResponse } from "./transaction-response";
 import { ConnectionInfo } from "./connection-info";
 import { PairRequest } from "./pair-request";
 import type { KnownNetwork } from "./wallet-metadata";
-declare global {
-  interface Crypto {
-    randomUUID: () => string;
-  }
-}
+import { createRandomId } from "./util";
 
 export const DEFAULT_CACHE_KEY = "hashconnect.data";
 
@@ -21,8 +17,8 @@ export class HashConnectCachedClient {
     const value = localStorage.getItem(cacheKey);
     const connection = !!value ? JSON.parse(value) as ConnectionInfo : {} as ConnectionInfo;
     if (!connection.topic || !connection.secret || !connection.pairedWallet) {
-      connection.topic = crypto.randomUUID();
-      connection.secret = crypto.randomUUID();
+      connection.topic = createRandomId();
+      connection.secret = createRandomId();
       connection.pairedWallet = undefined;
       localStorage.setItem(cacheKey, JSON.stringify(connection));
     }
@@ -58,8 +54,8 @@ export class HashConnectCachedClient {
 
   closeWallet(): void {
     if (this._connection.pairedWallet) {
-      this._connection.topic = crypto.randomUUID();
-      this._connection.secret = crypto.randomUUID();
+      this._connection.topic = createRandomId();
+      this._connection.secret = createRandomId();
       this._connection.pairedWallet = undefined;
       localStorage?.setItem(this._cacheKey, JSON.stringify(this._connection));
       this._client = new HashConnectClient();

--- a/packages/hapi-connect/src/client.ts
+++ b/packages/hapi-connect/src/client.ts
@@ -5,12 +5,8 @@ import { Relay } from "./relay";
 import { RelayMessage } from "./relay-message";
 import { TransactionResponse } from "./transaction-response";
 import { AdditionalAccountResponse } from "./additional-account-response";
+import { createRandomId } from "./util";
 
-declare global {
-  interface Crypto {
-    randomUUID: () => string;
-  }
-}
 declare type Handler = (value: RelayMessage) => boolean;
 
 export class HashConnectClient {
@@ -68,7 +64,7 @@ export class HashConnectClient {
     accountToSign: string,
     returnTransaction = false
   ): Promise<TransactionResponse> {
-    const id = crypto.randomUUID();
+    const id = createRandomId();
     this.send(topic, "Transaction", {
       id,
       topic,
@@ -96,7 +92,7 @@ export class HashConnectClient {
     network: string,
     multiAccount: boolean
   ): Promise<AdditionalAccountResponse> {
-    const id = crypto.randomUUID();
+    const id = createRandomId();
     this.send(topic, "AdditionalAccountRequest", {
       id,
       topic,

--- a/packages/hapi-connect/src/util.ts
+++ b/packages/hapi-connect/src/util.ts
@@ -1,0 +1,5 @@
+import * as ed from '@noble/ed25519';
+
+export function createRandomId() {
+    return ed.utils.bytesToHex(ed.utils.randomBytes(20));
+}

--- a/packages/hapi-mempool/package.json
+++ b/packages/hapi-mempool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbytes/hapi-mempool",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Hedera Mempool Client",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/bugbytesinc/hapi-proto#readme",
   "peerDependencies": {
-    "@bugbytes/hapi-proto": "0.31.9",
-    "@bugbytes/hapi-util": "0.31.9",
+    "@bugbytes/hapi-proto": "0.31.10",
+    "@bugbytes/hapi-util": "0.31.10",
     "long": ">=5.2.0",
     "protobufjs": ">=7.1.2"
   }

--- a/packages/hapi-mirror/package.json
+++ b/packages/hapi-mirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbytes/hapi-mirror",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Hedera Mirror Node Client",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/bugbytesinc/hapi-proto#readme",
   "peerDependencies": {
-    "@bugbytes/hapi-proto": "0.31.9",
-    "@bugbytes/hapi-util": "0.31.9",
+    "@bugbytes/hapi-proto": "0.31.10",
+    "@bugbytes/hapi-util": "0.31.10",
     "long": ">=5.2.0",
     "protobufjs": ">=7.1.2"
   }

--- a/packages/hapi-proto/package.json
+++ b/packages/hapi-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbytes/hapi-proto",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Hedera API Protobuf Typescript/Javascript Bindings",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",

--- a/packages/hapi-util/package.json
+++ b/packages/hapi-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbytes/hapi-util",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Hedera API Protobuf Typescript/Javascript Utilities",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bugbytesinc/hapi-proto#readme",
   "peerDependencies": {
-    "@bugbytes/hapi-proto": "0.31.9",
+    "@bugbytes/hapi-proto": "0.31.10",
     "@noble/ed25519": "^1.7.1",
     "@noble/secp256k1": "^1.7.0",
     "long": ">=5.2.0",


### PR DESCRIPTION
Changed the unique ID generation routine
from the intrinsic randomUUID() method to
one that utilizes the ed package (which is
already a dependency of the connect
package).  Downstream projects are having
random issues with relying on the intrinsic
crypto instance.